### PR TITLE
Compilation warnings

### DIFF
--- a/ufraw_conf.c
+++ b/ufraw_conf.c
@@ -1941,11 +1941,13 @@ int ufraw_process_args(int *argc, char ***argv, conf_data *cmd, conf_data *rc)
                     cmd->autoExposure = apply_state;
                     break;
                 }
+                // fall through
             case 'k':
                 if (!strcmp(optarg, "auto")) {
                     cmd->autoBlack = apply_state;
                     break;
                 }
+                // fall through
             case 'G':
             case 'L':
             case 's':

--- a/ufraw_developer.c
+++ b/ufraw_developer.c
@@ -387,7 +387,7 @@ static double findExpCoeff(double b)
     else a = b;
     bg = a / (1 - exp(-a));
     /* The limit on try is just to be sure there is no infinite loop. */
-    for (try = 0; abs(bg - b) > 0.001 || try < 100; try++) {
+    for (try = 0; fabs(bg - b) > 0.001 || try < 100; try++) {
                     a = a + (b - bg);
                     bg = a / (1 - exp(-a));
                 }

--- a/ufraw_message.c
+++ b/ufraw_message.c
@@ -152,8 +152,10 @@ char *ufraw_message(int code, const char *format, ...)
     switch (code) {
         case UFRAW_SET_ERROR:
             errorFlag = TRUE;
+            // fall through
         case UFRAW_SET_WARNING:
             errorBuffer = ufraw_message_buffer(errorBuffer, message);
+            // fall through
         case UFRAW_SET_LOG:
         case UFRAW_DCRAW_SET_LOG:
             logBuffer = ufraw_message_buffer(logBuffer, message);
@@ -161,6 +163,7 @@ char *ufraw_message(int code, const char *format, ...)
             return NULL;
         case UFRAW_GET_ERROR:
             if (!errorFlag) return NULL;
+            // fall through
         case UFRAW_GET_WARNING:
             return errorBuffer;
         case UFRAW_GET_LOG:
@@ -168,6 +171,7 @@ char *ufraw_message(int code, const char *format, ...)
         case UFRAW_CLEAN:
             g_free(logBuffer);
             logBuffer = NULL;
+            // fall through
         case UFRAW_RESET:
             g_free(errorBuffer);
             errorBuffer = NULL;

--- a/ufraw_ufraw.c
+++ b/ufraw_ufraw.c
@@ -1915,20 +1915,26 @@ void ufraw_unnormalize_rotation(ufraw_data *uf)
     switch (uf->conf->orientation) {
         case 5: /* Rotate 270 */
             uf->conf->rotationAngle += 90;
+            // fall through
         case 3: /* Rotate 180 */
             uf->conf->rotationAngle += 90;
+            // fall through
         case 6: /* Rotate 90 */
             uf->conf->rotationAngle += 90;
             uf->conf->orientation = 0;
+            // fall through
         case 0: /* No flip */
             break;
         case 4: /* Flip over diagonal "\" */
             uf->conf->rotationAngle += 90;
+            // fall through
         case 2: /* Flip vertical */
             uf->conf->rotationAngle += 90;
+            // fall through
         case 7: /* Flip over diagonal "/" */
             uf->conf->rotationAngle += 90;
             uf->conf->orientation = 1;
+            // fall through
         case 1: /* Flip horizontal */
             break;
         default:


### PR DESCRIPTION
A couple of commits to fix compilation warnings (I assume that `dcraw.cc` is periodically imported, so I didn't touch it).

Note that the change from `abs()` to `fabs()` is likely to have side-effects. However, on a quick test I couldn't notice anything wrong.