### PR TITLE
ufraw-gimp: properly send EXIF data to Gimp 2.9 and later

### DIFF
--- a/ufraw-gimp.c
+++ b/ufraw-gimp.c
@@ -438,6 +438,17 @@ long ufraw_save_gimp_image(ufraw_data *uf, GtkWidget *widget)
                           _("EXIF buffer length %d, too long, ignored."),
                           uf->outputExifBufLen);
         } else {
+#if HAVE_GIMP_2_9
+            GimpMetadata *metadata;
+            metadata = gimp_metadata_new();
+            if (gimp_metadata_set_from_exif(metadata,
+                                            uf->outputExifBuf,
+                                            uf->outputExifBufLen,
+                                            NULL)) {
+                gimp_image_set_metadata(uf->gimpImage, metadata);
+            }
+            g_object_unref(metadata);
+#else // !HAVE_GIMP_2_9
             GimpParasite *exif_parasite;
 
             exif_parasite = gimp_parasite_new("exif-data",
@@ -464,6 +475,7 @@ long ufraw_save_gimp_image(ufraw_data *uf, GtkWidget *widget)
                 }
             }
 #endif
+#endif // HAVE_GIMP_2_9
         }
     }
     /* Create "icc-profile" parasite from output profile

--- a/ufraw_preview.c
+++ b/ufraw_preview.c
@@ -4060,16 +4060,17 @@ static void control_button_event(GtkWidget *widget, long type)
                           (gpointer)response);
         if (!CFG->noExit)
             gtk_main_quit();
-    }
-    // Restore setting
-    CFG->shrink = shrinkSave;
-    CFG->size = sizeSave;
-    data->FreezeDialog = FALSE;
-    gtk_widget_set_sensitive(data->Controls, TRUE);
-    // cases that set error status require redrawing of the preview image
-    if (status != UFRAW_SUCCESS || CFG->noExit) {
-        ufraw_invalidate_layer(data->UF, ufraw_raw_phase);
-        render_preview(data);
+    } else {
+        // Restore setting
+        CFG->shrink = shrinkSave;
+        CFG->size = sizeSave;
+        data->FreezeDialog = FALSE;
+        gtk_widget_set_sensitive(data->Controls, TRUE);
+        // cases that set error status require redrawing of the preview image
+        if (status != UFRAW_SUCCESS || CFG->noExit) {
+            ufraw_invalidate_layer(data->UF, ufraw_raw_phase);
+            render_preview(data);
+        }
     }
 }
 


### PR DESCRIPTION
This is the fix for the first issue mentioned in #8 